### PR TITLE
Result Mapper & Error Interceptor

### DIFF
--- a/src/core/application/result-handler/result.mapper.ts
+++ b/src/core/application/result-handler/result.mapper.ts
@@ -1,0 +1,15 @@
+import { Result } from "./result";
+
+/**ResultMapper: Es un mapper que permite mapear un resultado a otro. */
+export class ResultMapper {
+    /**Permite mapear un resultado a otro.
+     * @param result Resultado a mapear.
+     * @param converter Función utilizada para mapear.
+     * @returns Resultado con el nuevo valor mapeado.*/
+    static async map<R, E>(result: Result<R>, converter: (value: R) => (Promise<E> | E)): Promise<Result<E>> {
+        if (result.IsSuccess) {
+            return Result.success(await converter(result.Value));
+        }
+        return Result.fail<E>(result.Error);
+    }
+}

--- a/src/core/application/result-handler/result.ts
+++ b/src/core/application/result-handler/result.ts
@@ -14,9 +14,9 @@ export class Result<T>{
         return this.value;
     }
 
-    /** Retorna el mensaje del error encapsulado. */
-    get Error(): string {
-        return this.error.message;
+    /** Retorna el error encapsulado. */
+    get Error(): Error {
+        return this.error;
     }
 
     /** Retorna `true` si el resultado fue exitoso, en caso contrario `false`. */

--- a/src/core/infrastructure/interceptors/exception.interceptor.ts
+++ b/src/core/infrastructure/interceptors/exception.interceptor.ts
@@ -1,0 +1,16 @@
+import { CallHandler, ExecutionContext, InternalServerErrorException, NestInterceptor, } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+export class ExceptionInterceptor implements NestInterceptor {
+    intercept(
+        _context: ExecutionContext,
+        next: CallHandler,
+    ): Observable<Error> {
+        return next.handle().pipe(
+            catchError(err => {
+                throw new InternalServerErrorException(err.message);
+            }),
+        );
+    }
+}

--- a/src/doctor/infrastructure/controllers/doctor.controller.ts
+++ b/src/doctor/infrastructure/controllers/doctor.controller.ts
@@ -24,6 +24,7 @@ import { DoctorGenderEnum } from 'src/doctor/domain/value-objects/doctor-gender.
 import { DoctorStatus } from 'src/doctor/domain/value-objects/doctor-status';
 import { DoctorStatusEnum } from 'src/doctor/domain/value-objects/doctor-status.enum';
 import { OrmDoctorMulMapper } from '../mappers/orm-doctor-mul-mapper';
+import { ResultMapper } from 'src/core/application/result-handler/result.mapper';
 
 @Controller('doctor')
 export class DoctorController {
@@ -38,7 +39,7 @@ export class DoctorController {
     }
 
     @Post('search')
-    async getDoctorsByCriteria(@Body() searchDoctorsByCriteriaApplicationServiceRequest: SearchDoctorsByCriteriaApplicationServiceRequest, @Query('pageIndex') pageIndex, @Query('pageSize') pageSize) {
+    async getDoctorsByCriteria(@Body() searchDoctorsByCriteriaApplicationServiceRequest: SearchDoctorsByCriteriaApplicationServiceRequest, @Query('pageIndex') pageIndex, @Query('pageSize') pageSize): Promise<Result<OrmDoctor[]>> {
         //Agregamos Paginación
         searchDoctorsByCriteriaApplicationServiceRequest.paging = { pageIndex: (pageIndex) ? pageIndex : 0, pageSize: (pageSize) ? pageSize : 100 };
 
@@ -53,7 +54,13 @@ export class DoctorController {
         //Ejecutamos el caso de uso
         const result = (await service.execute(searchDoctorsByCriteriaApplicationServiceRequest));
 
-        return (result.IsSuccess) ? Result.success(await this.ormDoctorMulMapper.fromDomainToOther(result.Value)) : result;
+        //Mapeamos y retornamos.
+        return ResultMapper.map(
+            result,
+            (value: Doctor[]) => {
+                return this.ormDoctorMulMapper.fromDomainToOther(value)
+            }
+        );
     }
 
     //#region EXTRAS

--- a/src/doctor/infrastructure/mappers/orm-doctor-mapper.ts
+++ b/src/doctor/infrastructure/mappers/orm-doctor-mapper.ts
@@ -16,6 +16,9 @@ export class OrmDoctorMapper implements IMapper<Doctor, OrmDoctor>{
     constructor(private readonly doctorRatingDomainService = new DoctorRatingDomainService()) { }
 
     async fromDomainToOther(domain: Doctor): Promise<OrmDoctor> {
+        //Verificamos que no sea null
+        if (!domain) { return null; }
+
         //Creamos un objeto de doctor de tipo ORM.
         const ormDoctor: OrmDoctor = await OrmDoctor.create(
             domain.Id.Value,
@@ -37,6 +40,9 @@ export class OrmDoctorMapper implements IMapper<Doctor, OrmDoctor>{
     }
 
     async fromOtherToDomain(other: OrmDoctor): Promise<Doctor> {
+        //Verificamos que no sea null
+        if (!other) { return null; }
+
         //Transformamos las especialidades del ORM a domain.
         const specialties: DoctorSpecialty[] = [];
         other.specialties.forEach((specialty) => {

--- a/src/doctor/infrastructure/mappers/orm-doctor-mul-mapper.ts
+++ b/src/doctor/infrastructure/mappers/orm-doctor-mul-mapper.ts
@@ -12,6 +12,10 @@ export class OrmDoctorMulMapper implements IMapper<Doctor[], OrmDoctor[]>{
     }
 
     async fromDomainToOther(domain: Doctor[]): Promise<OrmDoctor[]> {
+        //Verificamos que no sea null
+        if (!domain) { return null; }
+
+        //Transformamos
         const ormDoctors: OrmDoctor[] = [];
         for await (const doctor of domain) {
             ormDoctors.push(await this.ormDoctorMapper.fromDomainToOther(doctor));
@@ -21,8 +25,11 @@ export class OrmDoctorMulMapper implements IMapper<Doctor[], OrmDoctor[]>{
     }
 
     async fromOtherToDomain(other: OrmDoctor[]): Promise<Doctor[]> {
-        const doctors: Doctor[] = [];
+        //Verificamos que no sea null
+        if (!other) { return null; }
 
+        //Transformamos
+        const doctors: Doctor[] = [];
         for await (const ormDoctor of other) {
             doctors.push(await this.ormDoctorMapper.fromOtherToDomain(ormDoctor));
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import * as session from 'express-session';
 import * as passport from 'passport';
+import { ExceptionInterceptor } from './core/infrastructure/interceptors/exception.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -45,6 +46,8 @@ async function bootstrap() {
 
   app.use(passport.initialize());
   app.use(passport.session());
+
+  app.useGlobalInterceptors(new ExceptionInterceptor());
 
   await app.listen(Number.parseInt(process.env.PORT) || 3000);
 }


### PR DESCRIPTION
- Se implementó un Result Mapper para transformar un Result a otro.
- Se implementó un interceptor para capturar excepciones que no sean de dominio y encapsularlas en una excepción de Nest para que el servidor no se vea comprometido.